### PR TITLE
feat: 实现多通道队列路由与任务中断恢复机制

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -148,7 +148,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -274,7 +274,7 @@
     },
     {
       "id": 4,
-      "title": "错误率",
+      "title": "API 错误率",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -327,7 +327,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(tiebascraper_scraped_items_total{status=\"error\", forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(tiebascraper_api_request_duration_seconds_count{status=~\"error_.*|unexpected_error\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(tiebascraper_api_request_duration_seconds_count{instance=~\"$instance\"}[$__rate_interval])), 1)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -588,14 +588,14 @@
           "instant": true
         },
         {
-          "expr": "sum(tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"})",
+          "expr": "sum(tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"})",
           "legendFormat": "累计成功爬取",
           "refId": "E",
           "instant": true
         },
         {
-          "expr": "sum(tiebascraper_scraped_items_total{status=\"error\", forum=~\"$forum\", instance=~\"$instance\"})",
-          "legendFormat": "累计爬取错误",
+          "expr": "sum(tiebascraper_api_request_duration_seconds_count{status=~\"error_.*|unexpected_error\", instance=~\"$instance\"})",
+          "legendFormat": "累计 API 错误",
           "refId": "F",
           "instant": true
         },
@@ -676,7 +676,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum by (type) (rate(tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
           "legendFormat": "{{type}}",
           "refId": "A"
         }
@@ -731,7 +731,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (forum) (rate(tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum by (forum) (rate(tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
           "legendFormat": "{{forum}}",
           "refId": "A"
         }
@@ -739,7 +739,7 @@
     },
     {
       "id": 12,
-      "title": "爬取错误速率",
+      "title": "API 错误速率 (按方法)",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -784,8 +784,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type, forum) (rate(tiebascraper_scraped_items_total{status=\"error\", forum=~\"$forum\", instance=~\"$instance\"}[$__rate_interval]))",
-          "legendFormat": "{{type}} / {{forum}}",
+          "expr": "sum by (method, status) (rate(tiebascraper_api_request_duration_seconds_count{status=~\"error_.*|unexpected_error\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{method}} [{{status}}]",
           "refId": "A"
         }
       ]
@@ -834,7 +834,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"})",
+          "expr": "sum by (type) (tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"})",
           "legendFormat": "{{type}}",
           "refId": "A"
         }
@@ -884,7 +884,7 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (forum) (tiebascraper_scraped_items_total{status=\"success\", forum=~\"$forum\", instance=~\"$instance\"}))",
+          "expr": "topk(10, sum by (forum) (tiebascraper_scraped_items_total{forum=~\"$forum\", instance=~\"$instance\"}))",
           "legendFormat": "{{forum}}",
           "refId": "A"
         }
@@ -1360,7 +1360,7 @@
     },
     {
       "id": 30,
-      "title": "队列大小 (按优先级)",
+      "title": "队列大小 (按通道)",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -1409,7 +1409,7 @@
       "targets": [
         {
           "expr": "tiebascraper_queue_size{instance=~\"$instance\"}",
-          "legendFormat": "priority={{priority}}",
+          "legendFormat": "{{lane}}",
           "refId": "A"
         }
       ]

--- a/main.py
+++ b/main.py
@@ -91,20 +91,18 @@ async def _run_periodic_mode(scheduler: Scheduler, workers: list[Worker], router
                 except asyncio.CancelledError:
                     pass
 
-        total_remaining = router.total_qsize()
-        if total_remaining > 0:
-            logger.info(
-                "Waiting for {} tasks across all lanes to complete (timeout={}s)...",
-                total_remaining,
-                GRACEFUL_SHUTDOWN_TIMEOUT,
-            )
-            try:
-                join_tasks = [q.join() for q in router.lanes.values()]
-                await asyncio.wait_for(asyncio.gather(*join_tasks), timeout=GRACEFUL_SHUTDOWN_TIMEOUT)
-                logger.info("All queued tasks completed.")
-            except TimeoutError:
-                remaining = router.total_qsize()
-                logger.warning("Graceful shutdown timeout. {} tasks remaining across all lanes.", remaining)
+        logger.info(
+            "Waiting for all lane tasks to complete (timeout={}s, queued_now={})...",
+            GRACEFUL_SHUTDOWN_TIMEOUT,
+            router.total_qsize(),
+        )
+        try:
+            join_tasks = [q.join() for q in router.lanes.values()]
+            await asyncio.wait_for(asyncio.gather(*join_tasks), timeout=GRACEFUL_SHUTDOWN_TIMEOUT)
+            logger.info("All lane tasks completed.")
+        except TimeoutError:
+            remaining = router.total_qsize()
+            logger.warning("Graceful shutdown timeout. queued_now={} across all lanes.", remaining)
 
         worker_tasks = [t for t in tasks if t.get_name().startswith("worker-")]
         for t in worker_tasks:
@@ -166,20 +164,18 @@ async def _run_hybrid_mode(scheduler: Scheduler, workers: list[Worker], router: 
                 except asyncio.CancelledError:
                     pass
 
-        total_remaining = router.total_qsize()
-        if total_remaining > 0:
-            logger.info(
-                "Waiting for {} tasks across all lanes to complete (timeout={}s)...",
-                total_remaining,
-                GRACEFUL_SHUTDOWN_TIMEOUT,
-            )
-            try:
-                join_tasks = [q.join() for q in router.lanes.values()]
-                await asyncio.wait_for(asyncio.gather(*join_tasks), timeout=GRACEFUL_SHUTDOWN_TIMEOUT)
-                logger.info("All queued tasks completed.")
-            except TimeoutError:
-                remaining = router.total_qsize()
-                logger.warning("Graceful shutdown timeout. {} tasks remaining across all lanes.", remaining)
+        logger.info(
+            "Waiting for all lane tasks to complete (timeout={}s, queued_now={})...",
+            GRACEFUL_SHUTDOWN_TIMEOUT,
+            router.total_qsize(),
+        )
+        try:
+            join_tasks = [q.join() for q in router.lanes.values()]
+            await asyncio.wait_for(asyncio.gather(*join_tasks), timeout=GRACEFUL_SHUTDOWN_TIMEOUT)
+            logger.info("All lane tasks completed.")
+        except TimeoutError:
+            remaining = router.total_qsize()
+            logger.warning("Graceful shutdown timeout. queued_now={} across all lanes.", remaining)
 
         worker_tasks = [t for t in tasks if t.get_name().startswith("worker-")]
         for t in worker_tasks:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -183,6 +183,17 @@ class DeepScanConfig(BaseModel):
     depth: int = Field(3, gt=0)
 
 
+class WorkerConfig(BaseModel):
+    """Worker 并发配置模型
+
+    按通道设置 Worker 数量，每条通道独立占用对应 API 接口的限速配额。
+    """
+
+    threads: int = Field(default=1, gt=0)
+    posts: int = Field(default=2, gt=0)
+    comments: int = Field(default=2, gt=0)
+
+
 class PydanticConfig(BaseSettings):
     """Pydantic总配置模型"""
 
@@ -204,6 +215,7 @@ class PydanticConfig(BaseSettings):
         default_factory=lambda: SchedulerConfig(interval_seconds=60, good_page_every_n_ticks=10)
     )
     deep_scan: DeepScanConfig = Field(default_factory=lambda: DeepScanConfig(enabled=False, depth=3))
+    worker: WorkerConfig = Field(default_factory=WorkerConfig)
     websocket: WebSocketConfig = Field(default_factory=lambda: WebSocketConfig(host="localhost", port=8000))
     consumer: ConsumerConfig = Field(
         default_factory=lambda: ConsumerConfig(transport="none", max_len=10000, stream_prefix="scraper:tieba:events")
@@ -455,6 +467,21 @@ class Config:
     def deep_scan_depth(self) -> int:
         """获取 DeepScan 深度扫描的页数深度。"""
         return self.pydantic_config.deep_scan.depth
+
+    @property
+    def worker_threads(self) -> int:
+        """获取 threads 通道的 Worker 数量。"""
+        return self.pydantic_config.worker.threads
+
+    @property
+    def worker_posts(self) -> int:
+        """获取 posts 通道的 Worker 数量。"""
+        return self.pydantic_config.worker.posts
+
+    @property
+    def worker_comments(self) -> int:
+        """获取 comments 通道的 Worker 数量。"""
+        return self.pydantic_config.worker.comments
 
     @property
     def websocket_url(self) -> WebsocketUrl:

--- a/src/core/lock.py
+++ b/src/core/lock.py
@@ -1,0 +1,71 @@
+"""分布式锁管理器模块。
+
+提供 Redis 和内存两种锁实现，通过统一的协议接口供 TaskHandler 使用。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Protocol
+
+
+class LockManager(Protocol):
+    """锁管理器协议。"""
+
+    async def acquire(self, key: str, ttl: int = 300) -> bool:
+        """尝试获取锁。
+
+        Args:
+            key: 锁的唯一标识键。
+            ttl: 锁的过期时间（秒），默认 300 秒。
+
+        Returns:
+            是否成功获取锁。
+        """
+        ...
+
+    async def release(self, key: str) -> None:
+        """释放锁（幂等）。
+
+        Args:
+            key: 锁的唯一标识键。
+        """
+        ...
+
+
+class RedisLockManager:
+    """基于 Redis ``SET NX`` 的分布式锁管理器。"""
+
+    def __init__(self, redis_client) -> None:
+        self._redis = redis_client
+
+    async def acquire(self, key: str, ttl: int = 300) -> bool:
+        return await self._redis.set(key, "1", ex=ttl, nx=True)
+
+    async def release(self, key: str) -> None:
+        await self._redis.delete(key)
+
+
+class MemoryLockManager:
+    """基于内存字典的锁管理器（单进程降级方案）。"""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, float] = {}
+        self._guard = asyncio.Lock()
+
+    async def acquire(self, key: str, ttl: int = 300) -> bool:
+        async with self._guard:
+            now = time.time()
+            # 清理过期锁，保留未过期的锁
+            self._locks = {k: t for k, t in self._locks.items() if now <= t}
+
+            if key in self._locks:
+                return False
+
+            self._locks[key] = now + ttl
+            return True
+
+    async def release(self, key: str) -> None:
+        async with self._guard:
+            self._locks.pop(key, None)

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -6,7 +6,7 @@ from prometheus_client import Counter, Gauge, Histogram
 SCRAPED_ITEMS = Counter(
     "tiebascraper_scraped_items_total",
     "Total number of items scraped",
-    ["type", "forum", "status"],  # type: thread, post, comment; status: success, error
+    ["type", "forum"],  # type: thread, post, comment
 )
 
 # 任务处理耗时分布
@@ -20,7 +20,9 @@ TASK_DURATION = Histogram(
 API_REQUEST_DURATION = Histogram(
     "tiebascraper_api_request_duration_seconds",
     "Time spent on actual API network requests",
-    ["method", "status"],  # method: get_threads, etc.; status: 'error_deleted', 'error_<code>', or 'unexpected_error'
+    # method: get_threads, etc.
+    # status: 'success', 'error_deleted', 'error_<code>', or 'unexpected_error'
+    ["method", "status"],
     buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0),
 )
 
@@ -35,7 +37,7 @@ RATELIMIT_WAIT_DURATION = Histogram(
 QUEUE_SIZE = Gauge(
     "tiebascraper_queue_size",
     "Current number of tasks in the queue",
-    ["priority"],
+    ["lane"],  # lane: threads, posts, comments
 )
 
 # 活跃 Worker 数量

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,0 +1,72 @@
+"""本地 ORM 模型。
+
+定义 TiebaScraper 内部使用的辅助数据库模型。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import BigInteger, Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+from tiebameow.models.orm import Base
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+class PendingThreadScan(Base):
+    """标记全量扫描尚未完成的 Thread。
+
+    程序重启时可读取本表恢复未完成的扫描任务。
+
+    Attributes:
+        tid: 主题贴 tid（主键）
+        fid: 贴吧 fid（恢复任务时可用于日志）
+        fname: 贴吧名（恢复任务时可用于日志）
+        backfill: 是否为回溯任务
+        created_at: 记录创建时间
+    """
+
+    __tablename__ = "pending_thread_scan"
+
+    tid: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    fid: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    fname: Mapped[str] = mapped_column(String(255), nullable=False)
+    backfill: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now_utc)
+
+    def to_dict(self) -> dict:
+        result = {}
+        for c in self.__table__.columns:
+            result[c.name] = getattr(self, c.name)
+        return result
+
+
+class PendingCommentScan(Base):
+    """标记楼中楼扫描尚未完成的 Post。
+
+    用于恢复 FullScanCommentsTask / IncrementalScanCommentsTask。
+
+    Attributes:
+        tid: 主题贴 tid
+        pid: 回复 pid
+        backfill: 是否为回溯任务
+        task_kind: 任务类型（"full" 或 "incremental"）
+        created_at: 记录创建时间
+    """
+
+    __tablename__ = "pending_comment_scan"
+
+    tid: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    pid: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    backfill: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    task_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now_utc)
+
+    def to_dict(self) -> dict:
+        result = {}
+        for c in self.__table__.columns:
+            result[c.name] = getattr(self, c.name)
+        return result

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -36,7 +36,9 @@ class PendingThreadScan(Base):
     def to_dict(self) -> dict:
         result = {}
         for c in self.__table__.columns:
-            result[c.name] = getattr(self, c.name)
+            value = getattr(self, c.name)
+            if value is not None:
+                result[c.name] = value
         return result
 
 
@@ -64,5 +66,7 @@ class PendingCommentScan(Base):
     def to_dict(self) -> dict:
         result = {}
         for c in self.__table__.columns:
-            result[c.name] = getattr(self, c.name)
+            value = getattr(self, c.name)
+            if value is not None:
+                result[c.name] = value
         return result

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -5,15 +5,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime  # noqa: TC003
 
-from sqlalchemy import BigInteger, Boolean, DateTime, String
+from sqlalchemy import BigInteger, Boolean, DateTime, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 from tiebameow.models.orm import Base
-
-
-def _now_utc() -> datetime:
-    return datetime.now(tz=UTC)
 
 
 class PendingThreadScan(Base):
@@ -35,7 +31,7 @@ class PendingThreadScan(Base):
     fid: Mapped[int] = mapped_column(BigInteger, nullable=False)
     fname: Mapped[str] = mapped_column(String(255), nullable=False)
     backfill: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now_utc)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     def to_dict(self) -> dict:
         result = {}
@@ -63,7 +59,7 @@ class PendingCommentScan(Base):
     pid: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     backfill: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     task_kind: Mapped[str] = mapped_column(String(16), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now_utc)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     def to_dict(self) -> dict:
         result = {}

--- a/src/scraper/__init__.py
+++ b/src/scraper/__init__.py
@@ -6,7 +6,8 @@
 - 各种任务定义和处理器
 """
 
+from .router import QueueRouter
 from .scheduler import Scheduler
 from .worker import Worker
 
-__all__ = ["Scheduler", "Worker"]
+__all__ = ["QueueRouter", "Scheduler", "Worker"]

--- a/src/scraper/queue.py
+++ b/src/scraper/queue.py
@@ -18,15 +18,17 @@ class UniquePriorityQueue:
     """带去重功能的优先级队列。
 
     该队列维护一个已入队任务的集合，在入队时检查是否已存在相同任务（相同优先级和内容）。
-    如果存在，则跳过入队操作。出队时会从集合中移除对应记录。
+    如果存在，则跳过入队操作。任务完成并调用 ``task_done`` 时会从集合中移除对应记录。
 
     Attributes:
-        _unique_set: 存储已入队任务的唯一标识集合。
+        lane: 所属通道名称，用于 Prometheus 指标标签。
+        _unique_set: 存储已入队或处理中任务的唯一标识集合。
         _q: 内部 asyncio.PriorityQueue
     """
 
-    def __init__(self, maxsize: int = 0):
-        self._q = asyncio.PriorityQueue(maxsize=maxsize)
+    def __init__(self, lane: str = "unknown", maxsize: int = 0):
+        self.lane = lane
+        self._q: asyncio.PriorityQueue[Task] = asyncio.PriorityQueue(maxsize=maxsize)
         self._unique_set: set[tuple[int, str, object]] = set()
 
     def _get_unique_key(self, item: Task) -> tuple[int, str, object]:
@@ -54,8 +56,8 @@ class UniquePriorityQueue:
         self._unique_set.add(unique_key)
         try:
             self._q.put_nowait(item)
-            QUEUE_SIZE.labels(priority=item.priority.name).inc()
-        except Exception:
+            QUEUE_SIZE.labels(lane=self.lane).inc()
+        except BaseException:
             self._unique_set.discard(unique_key)
             raise
 
@@ -68,33 +70,29 @@ class UniquePriorityQueue:
         self._unique_set.add(unique_key)
         try:
             await self._q.put(item)
-            QUEUE_SIZE.labels(priority=item.priority.name).inc()
-        except Exception:
+            QUEUE_SIZE.labels(lane=self.lane).inc()
+        except BaseException:
             self._unique_set.discard(unique_key)
             raise
 
     async def get(self) -> Task:
-        """获取任务，并从去重集合中移除。"""
+        """获取任务。"""
         item = await self._q.get()
-        QUEUE_SIZE.labels(priority=item.priority.name).dec()
-        try:
-            unique_key = self._get_unique_key(item)
-            self._unique_set.discard(unique_key)
-        except Exception:
-            pass
+        QUEUE_SIZE.labels(lane=self.lane).dec()
         return item
 
     def get_nowait(self) -> Task:
         item = self._q.get_nowait()
-        QUEUE_SIZE.labels(priority=item.priority.name).dec()
-        try:
-            unique_key = self._get_unique_key(item)
-            self._unique_set.discard(unique_key)
-        except Exception:
-            pass
+        QUEUE_SIZE.labels(lane=self.lane).dec()
         return item
 
-    def task_done(self):
+    def task_done(self, item: Task | None = None):
+        if item is not None:
+            try:
+                unique_key = self._get_unique_key(item)
+                self._unique_set.discard(unique_key)
+            except Exception:
+                pass
         self._q.task_done()
 
     async def join(self):

--- a/src/scraper/router.py
+++ b/src/scraper/router.py
@@ -1,0 +1,102 @@
+"""多通道队列路由器。
+
+根据 API 资源类型将任务路由到不同的 ``UniquePriorityQueue``，
+让每条通道拥有独立的 Worker 组，从而利用独立限速最大化吞吐量。
+
+通道映射：
+- threads: ``ScanThreadsTask``
+- posts:   ``FullScanPostsTask``, ``IncrementalScanPostsTask``, ``DeepScanTask``
+- comments: ``FullScanCommentsTask``, ``IncrementalScanCommentsTask``
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from .queue import UniquePriorityQueue
+
+if TYPE_CHECKING:
+    from .tasks import (
+        DeepScanTask,
+        FullScanCommentsTask,
+        FullScanPostsTask,
+        IncrementalScanCommentsTask,
+        IncrementalScanPostsTask,
+        ScanThreadsTask,
+        Task,
+    )
+
+    type TaskContent = (
+        ScanThreadsTask
+        | FullScanPostsTask
+        | IncrementalScanPostsTask
+        | FullScanCommentsTask
+        | IncrementalScanCommentsTask
+        | DeepScanTask
+    )
+
+type Lane = Literal["threads", "posts", "comments"]
+
+# task content 类名 → 通道名
+_LANE_MAP: dict[str, Lane] = {
+    "ScanThreadsTask": "threads",
+    "FullScanPostsTask": "posts",
+    "IncrementalScanPostsTask": "posts",
+    "DeepScanTask": "posts",
+    "FullScanCommentsTask": "comments",
+    "IncrementalScanCommentsTask": "comments",
+}
+
+
+class QueueRouter:
+    """多通道队列路由器。
+
+    维护 3 条独立的 ``UniquePriorityQueue``，提供按通道名或任务类型
+    自动路由的 ``put`` 方法。
+
+    Attributes:
+        threads_queue: threads 通道队列
+        posts_queue: posts 通道队列
+        comments_queue: comments 通道队列
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self.threads_queue = UniquePriorityQueue(lane="threads", maxsize=maxsize)
+        self.posts_queue = UniquePriorityQueue(lane="posts", maxsize=maxsize)
+        self.comments_queue = UniquePriorityQueue(lane="comments", maxsize=maxsize)
+        self._queues: dict[Lane, UniquePriorityQueue] = {
+            "threads": self.threads_queue,
+            "posts": self.posts_queue,
+            "comments": self.comments_queue,
+        }
+
+    def get_queue(self, lane: Lane) -> UniquePriorityQueue:
+        """获取指定通道的队列。"""
+        return self._queues[lane]
+
+    def resolve_lane(self, task: Task) -> Lane:
+        """根据任务内容类型解析通道名。"""
+        cls_name = type(task.content).__name__
+        lane = _LANE_MAP.get(cls_name)
+        if lane is None:
+            raise ValueError(f"Unknown task content type: {cls_name}")
+        return lane
+
+    async def put(self, task: Task) -> None:
+        """自动路由任务到对应通道队列。"""
+        lane = self.resolve_lane(task)
+        await self._queues[lane].put(task)
+
+    def put_nowait(self, task: Task) -> None:
+        """非阻塞版本的自动路由入队。"""
+        lane = self.resolve_lane(task)
+        self._queues[lane].put_nowait(task)
+
+    def total_qsize(self) -> int:
+        """所有通道队列的总任务数。"""
+        return sum(q.qsize() for q in self._queues.values())
+
+    @property
+    def lanes(self) -> dict[Lane, UniquePriorityQueue]:
+        """返回所有通道队列的字典。"""
+        return dict(self._queues)

--- a/src/scraper/worker.py
+++ b/src/scraper/worker.py
@@ -1090,8 +1090,8 @@ class IncrementalScanCommentsTaskHandler(TaskHandler):
 
     async def _finalize_comment_scan(self, tid: int, pid: int) -> None:
         """移除 pending_comment_scan 标记，表示该评论扫描任务已完成。"""
-        await self.datastore.remove_pending_comment_scan(tid, pid)
-        self.log.debug("Removed pending_comment_scan marker for tid={}, pid={}", tid, pid)
+        await self.datastore.remove_pending_comment_scan(tid, pid, task_kind="incremental")
+        self.log.debug("Removed incremental pending_comment_scan marker for tid={}, pid={}", tid, pid)
 
     async def _scan_comment_pages(
         self,

--- a/src/scraper/worker.py
+++ b/src/scraper/worker.py
@@ -430,7 +430,7 @@ class FullScanPostsTaskHandler(TaskHandler):
 
         主要流程：
         从第一页逐页扫描并处理主题贴的回复内容，直至has_more为False。
-        任务完成后，更新主题贴的元数据到数据库。
+        任务完成后，移除主题贴的 pending_scan 标记。
 
         Args:
             task_content: ScanPostsTask实例，包含主题贴tid和每页条目数量。
@@ -482,7 +482,7 @@ class FullScanPostsTaskHandler(TaskHandler):
         except UnretriableApiError as e:
             if e.code == 4:
                 self.log.warning(
-                    "Thread tid={} may have been deleted (err_code=4). Saving thread metadata from pending scan.", tid
+                    "Thread tid={} may have been deleted (err_code=4). Clearing pending_scan marker and skipping.", tid
                 )
                 await self._finalize_thread(tid)
             else:

--- a/src/scraper/worker.py
+++ b/src/scraper/worker.py
@@ -1333,6 +1333,12 @@ class DeepScanTaskHandler(TaskHandler):
                 )
 
                 if post.reply_num > 10 or len(post.comments) != post.reply_num:
+                    await self.datastore.add_pending_comment_scan(
+                        tid=post.tid,
+                        pid=post.pid,
+                        backfill=False,
+                        task_kind="incremental",
+                    )
                     update_task = IncrementalScanCommentsTask(
                         tid=post.tid,
                         pid=post.pid,

--- a/src/scraper/worker.py
+++ b/src/scraper/worker.py
@@ -938,6 +938,8 @@ class FullScanCommentsTaskHandler(TaskHandler):
             initial_page_data = await self.get_comments(tid, pid, pn=1)
 
             if not initial_page_data or not initial_page_data.objs:
+                await self._finalize_comment_scan(tid, pid)
+
                 self.log.debug("Post pid={} in tid={} has no comments or has been deleted. Task finished.", pid, tid)
                 return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,8 @@ class DummyConfig:
     backfill_force_scan: bool = False
     deep_scan_enabled: bool = False
     deep_scan_depth: int = 3
+    queue_depth_threshold: int = 0
+    skip_wait_seconds: int = 1
     default_forums: list[str] = field(default_factory=lambda: ["bar", "baz"])
     groups: list = field(default_factory=list)
 

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,35 @@
+"""core.models 行为测试。"""
+
+from datetime import UTC, datetime
+
+from src.core.models import PendingCommentScan, PendingThreadScan
+
+
+def test_pending_thread_scan_to_dict_omits_none_created_at():
+    """created_at 未设置时，to_dict 不应包含该字段。"""
+    model = PendingThreadScan(tid=1, fid=10, fname="bar", backfill=False)
+
+    payload = model.to_dict()
+
+    assert "created_at" not in payload
+    assert payload["tid"] == 1
+    assert payload["fid"] == 10
+    assert payload["fname"] == "bar"
+    assert payload["backfill"] is False
+
+
+def test_pending_comment_scan_to_dict_keeps_created_at_when_set():
+    """created_at 已设置时，to_dict 应包含该字段。"""
+    created_at = datetime.now(UTC)
+    model = PendingCommentScan(
+        tid=1,
+        pid=2,
+        backfill=False,
+        task_kind="full",
+        created_at=created_at,
+    )
+
+    payload = model.to_dict()
+
+    assert payload["created_at"] == created_at
+    assert payload["task_kind"] == "full"

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -75,29 +75,61 @@ async def test_memory_lock_concurrent_acquire():
 async def test_redis_lock_acquire_success():
     """RedisLockManager 获取锁成功"""
     redis = AsyncMock()
-    redis.set = AsyncMock(return_value=True)
+    # 模拟 redis.lock() 返回一个 lock 对象 (同步方法)
+    mock_lock = AsyncMock()
+    mock_lock.acquire.return_value = True
+    redis.lock = Mock(return_value=mock_lock)
 
     lm = RedisLockManager(redis)
     assert await lm.acquire("key:1", ttl=60)
-    redis.set.assert_awaited_once_with("key:1", "1", ex=60, nx=True)
+
+    # 验证创建了锁对象并调用了 acquire
+    redis.lock.assert_called_once_with("key:1", timeout=60)
+    mock_lock.acquire.assert_awaited_once_with(blocking=False)
+
+    # 验证 lock 对象被保存
+    assert lm._locks["key:1"] == mock_lock
 
 
 @pytest.mark.asyncio
 async def test_redis_lock_acquire_fail():
     """RedisLockManager 获取锁失败（已被其他人持有）"""
     redis = AsyncMock()
-    redis.set = AsyncMock(return_value=False)
+    mock_lock = AsyncMock()
+    mock_lock.acquire.return_value = False  # 获取失败
+    redis.lock = Mock(return_value=mock_lock)
 
     lm = RedisLockManager(redis)
     assert not await lm.acquire("key:1", ttl=60)
 
+    # 验证没有保存 lock 对象
+    assert "key:1" not in lm._locks
+
 
 @pytest.mark.asyncio
-async def test_redis_lock_release():
-    """RedisLockManager 释放锁"""
+async def test_redis_lock_release_owned():
+    """RedisLockManager 释放自己持有的锁"""
     redis = AsyncMock()
-    redis.delete = AsyncMock()
-
     lm = RedisLockManager(redis)
+
+    # 模拟持有锁
+    mock_lock = AsyncMock()
+    lm._locks["key:1"] = mock_lock
+
     await lm.release("key:1")
-    redis.delete.assert_awaited_once_with("key:1")
+
+    # 验证调用了 release
+    mock_lock.release.assert_awaited_once()
+    assert "key:1" not in lm._locks
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_release_not_owned():
+    """RedisLockManager 尝试释放不属于自己的锁（应被忽略）"""
+    redis = AsyncMock()
+    lm = RedisLockManager(redis)
+    # 本地没有 lock 记录
+
+    await lm.release("key:1")
+    # 不抛出异常，也没动作
+    assert True

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,103 @@
+"""LockManager 单元测试。"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.core.lock import MemoryLockManager, RedisLockManager
+
+# ==================== MemoryLockManager 测试 ====================
+
+
+@pytest.mark.asyncio
+async def test_memory_lock_acquire_and_release():
+    """基本的获取和释放锁"""
+    lm = MemoryLockManager()
+
+    assert await lm.acquire("key:1", ttl=60)
+    # 重复获取同一个锁应失败
+    assert not await lm.acquire("key:1", ttl=60)
+    # 释放后可以重新获取
+    await lm.release("key:1")
+    assert await lm.acquire("key:1", ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_memory_lock_different_keys():
+    """不同的 key 互不影响"""
+    lm = MemoryLockManager()
+
+    assert await lm.acquire("key:1", ttl=60)
+    assert await lm.acquire("key:2", ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_memory_lock_expired_auto_release():
+    """过期的锁应自动释放"""
+    lm = MemoryLockManager()
+
+    # 使用极短 TTL
+    assert await lm.acquire("key:1", ttl=0)
+    # 稍等一下让锁过期
+    await asyncio.sleep(0.01)
+    # 应该可以重新获取
+    assert await lm.acquire("key:1", ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_memory_lock_release_idempotent():
+    """释放不存在的锁不应报错"""
+    lm = MemoryLockManager()
+    # 不应该抛出任何异常
+    await lm.release("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_memory_lock_concurrent_acquire():
+    """并发获取同一个锁，应只有一个成功"""
+    lm = MemoryLockManager()
+    results = await asyncio.gather(
+        lm.acquire("key:1", ttl=60),
+        lm.acquire("key:1", ttl=60),
+        lm.acquire("key:1", ttl=60),
+    )
+    assert results.count(True) == 1
+    assert results.count(False) == 2
+
+
+# ==================== RedisLockManager 测试 ====================
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_acquire_success():
+    """RedisLockManager 获取锁成功"""
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+
+    lm = RedisLockManager(redis)
+    assert await lm.acquire("key:1", ttl=60)
+    redis.set.assert_awaited_once_with("key:1", "1", ex=60, nx=True)
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_acquire_fail():
+    """RedisLockManager 获取锁失败（已被其他人持有）"""
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=False)
+
+    lm = RedisLockManager(redis)
+    assert not await lm.acquire("key:1", ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_release():
+    """RedisLockManager 释放锁"""
+    redis = AsyncMock()
+    redis.delete = AsyncMock()
+
+    lm = RedisLockManager(redis)
+    await lm.release("key:1")
+    redis.delete.assert_awaited_once_with("key:1")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,156 @@
+"""QueueRouter 单元测试。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from src.scraper.router import QueueRouter
+from src.scraper.tasks import (
+    DeepScanTask,
+    FullScanCommentsTask,
+    FullScanPostsTask,
+    IncrementalScanCommentsTask,
+    IncrementalScanPostsTask,
+    Priority,
+    ScanThreadsTask,
+    Task,
+)
+
+# ==================== 路由映射测试 ====================
+
+
+@pytest.mark.asyncio
+async def test_router_routes_threads_task():
+    """ScanThreadsTask 应路由到 threads 通道"""
+    router = QueueRouter()
+    task = Task(priority=Priority.HIGH, content=ScanThreadsTask(fid=1, fname="test", pn=1))
+    await router.put(task)
+
+    assert router.threads_queue.qsize() == 1
+    assert router.posts_queue.qsize() == 0
+    assert router.comments_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_router_routes_posts_tasks():
+    """FullScanPostsTask / IncrementalScanPostsTask / DeepScanTask 应路由到 posts 通道"""
+    router = QueueRouter()
+
+    tasks = [
+        Task(priority=Priority.MEDIUM, content=FullScanPostsTask(tid=1)),
+        Task(
+            priority=Priority.MEDIUM,
+            content=IncrementalScanPostsTask(
+                tid=2,
+                stored_last_time=datetime(2024, 1, 1, 0, 0, 0),
+                stored_reply_num=0,
+                target_last_time=None,
+                target_reply_num=10,
+            ),
+        ),
+        Task(priority=Priority.MEDIUM, content=DeepScanTask(tid=3, total_pages=10)),
+    ]
+    for t in tasks:
+        await router.put(t)
+
+    assert router.threads_queue.qsize() == 0
+    assert router.posts_queue.qsize() == 3
+    assert router.comments_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_router_routes_comments_tasks():
+    """FullScanCommentsTask / IncrementalScanCommentsTask 应路由到 comments 通道"""
+    router = QueueRouter()
+
+    tasks = [
+        Task(priority=Priority.LOW, content=FullScanCommentsTask(tid=1, pid=10)),
+        Task(priority=Priority.LOW, content=IncrementalScanCommentsTask(tid=1, pid=20)),
+    ]
+    for t in tasks:
+        await router.put(t)
+
+    assert router.threads_queue.qsize() == 0
+    assert router.posts_queue.qsize() == 0
+    assert router.comments_queue.qsize() == 2
+
+
+# ==================== resolve_lane 测试 ====================
+
+
+def test_resolve_lane_unknown_raises():
+    """未知任务类型应抛出 ValueError"""
+    from dataclasses import dataclass
+
+    @dataclass
+    class UnknownContent:
+        unique_key: int = 0
+
+    router = QueueRouter()
+    task = Task(priority=Priority.HIGH, content=UnknownContent())  # type: ignore
+    with pytest.raises(ValueError, match="Unknown task content type"):
+        router.resolve_lane(task)
+
+
+# ==================== put_nowait 测试 ====================
+
+
+def test_put_nowait():
+    """put_nowait 同步入队"""
+    router = QueueRouter()
+    task = Task(priority=Priority.HIGH, content=ScanThreadsTask(fid=1, fname="t", pn=1))
+    router.put_nowait(task)
+    assert router.threads_queue.qsize() == 1
+
+
+# ==================== total_qsize 测试 ====================
+
+
+@pytest.mark.asyncio
+async def test_total_qsize():
+    """total_qsize 返回所有通道的总任务数"""
+    router = QueueRouter()
+    await router.put(Task(priority=Priority.HIGH, content=ScanThreadsTask(fid=1, fname="t", pn=1)))
+    await router.put(Task(priority=Priority.MEDIUM, content=FullScanPostsTask(tid=1)))
+    await router.put(Task(priority=Priority.LOW, content=FullScanCommentsTask(tid=1, pid=10)))
+
+    assert router.total_qsize() == 3
+
+
+# ==================== get_queue / lanes 测试 ====================
+
+
+def test_get_queue():
+    """get_queue 返回对应通道的队列"""
+    router = QueueRouter()
+    assert router.get_queue("threads") is router.threads_queue
+    assert router.get_queue("posts") is router.posts_queue
+    assert router.get_queue("comments") is router.comments_queue
+
+
+def test_lanes_property():
+    """lanes 属性返回所有通道的字典副本"""
+    router = QueueRouter()
+    lanes = router.lanes
+    assert set(lanes.keys()) == {"threads", "posts", "comments"}
+    # 应该是副本, 修改不影响内部状态
+    lanes.pop("threads")
+    assert "threads" in router.lanes
+
+
+# ==================== 去重测试（继承自 UniquePriorityQueue）====================
+
+
+@pytest.mark.asyncio
+async def test_router_dedup():
+    """同一 unique_key 任务不应重复入队"""
+    router = QueueRouter()
+    t1 = Task(priority=Priority.HIGH, content=FullScanPostsTask(tid=1))
+    t2 = Task(priority=Priority.HIGH, content=FullScanPostsTask(tid=1))
+
+    await router.put(t1)
+    await router.put(t2)
+
+    assert router.posts_queue.qsize() == 1

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -99,11 +99,11 @@ async def test_threads_handler_new_threads_schedule_and_push():
     # 应该原子保存 thread 元数据与 pending_scan
     datastore.save_threads_and_pending_scans.assert_awaited_once()
     atomic_call = datastore.save_threads_and_pending_scans.await_args
-    thread_models = atomic_call.args[0]
-    pending_scans = atomic_call.args[1]
-    assert thread_models is not None
-    assert isinstance(thread_models[0], ThreadModel)
-    assert pending_scans
+    thread_dtos = atomic_call.args[0]
+    assert thread_dtos is not None
+    assert thread_dtos[0].tid == thread.tid
+    assert atomic_call.kwargs.get("backfill") is False
+    assert atomic_call.kwargs.get("upsert_threads") is False
 
     # 应该生成 FullScanPostsTask
     queued_tasks = _drain_router(router)
@@ -137,11 +137,11 @@ async def test_threads_handler_new_thread_zero_replies():
     # 没有回复的主题帖也应通过原子方法保存元数据
     datastore.save_threads_and_pending_scans.assert_awaited_once()
     atomic_call = datastore.save_threads_and_pending_scans.await_args
-    thread_models = atomic_call.args[0]
-    pending_scans = atomic_call.args[1]
-    assert thread_models is not None
-    assert isinstance(thread_models[0], ThreadModel)
-    assert pending_scans == []
+    thread_dtos = atomic_call.args[0]
+    assert thread_dtos is not None
+    assert thread_dtos[0].tid == thread.tid
+    assert atomic_call.kwargs.get("backfill") is False
+    assert atomic_call.kwargs.get("upsert_threads") is False
 
     # 不应该生成 FullScanPostsTask
     queued_tasks = _drain_router(router)

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -18,7 +18,8 @@ from conftest import (
 from tiebameow.models.orm import Post as PostModel
 from tiebameow.models.orm import Thread as ThreadModel
 
-from src.scraper.queue import UniquePriorityQueue
+from src.core.lock import MemoryLockManager
+from src.scraper.router import QueueRouter
 from src.scraper.tasks import (
     FullScanCommentsTask,
     FullScanPostsTask,
@@ -37,15 +38,17 @@ from src.scraper.worker import (
 )
 
 
-def _drain_queue(queue: UniquePriorityQueue) -> list[Task]:
-    """从队列中取出所有任务"""
+def _drain_router(router: QueueRouter) -> list[Task]:
+    """从路由器的所有通道队列中取出所有任务"""
     items: list[Task] = []
-    while not queue.empty():
-        items.append(queue.get_nowait())
+    for q in router.lanes.values():
+        while not q.empty():
+            items.append(q.get_nowait())
     return items
 
 
 def create_mock_container(tb_client=None, redis_client=None, config=None):
+    lock_manager = MemoryLockManager()
     return cast(
         "Any",
         SimpleNamespace(
@@ -57,6 +60,7 @@ def create_mock_container(tb_client=None, redis_client=None, config=None):
             posts_limiter=AsyncMock(),
             comments_limiter=AsyncMock(),
             limiter=AsyncMock(),
+            lock_manager=lock_manager,
         ),
     )
 
@@ -67,8 +71,6 @@ def create_mock_container(tb_client=None, redis_client=None, config=None):
 @pytest.mark.asyncio
 async def test_threads_handler_new_threads_schedule_and_push():
     """测试 ThreadsTaskHandler 处理新主题帖"""
-    Worker._memory_locks.clear()
-
     thread = make_thread(tid=1, reply_num=5)
     threads_response = make_threads_response([thread])
 
@@ -76,15 +78,16 @@ async def test_threads_handler_new_threads_schedule_and_push():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value={thread.tid}),
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(ScanThreadsTask(fid=thread.fid, fname=thread.fname, pn=1))
@@ -92,16 +95,23 @@ async def test_threads_handler_new_threads_schedule_and_push():
     # 新主题帖应该推送到对象流
     datastore.push_object_event.assert_awaited_once_with("thread", thread)
 
+    # 应该原子保存 thread 元数据与 pending_scan
+    datastore.save_threads_and_pending_scans.assert_awaited_once()
+    atomic_call = datastore.save_threads_and_pending_scans.await_args
+    thread_models = atomic_call.args[0]
+    pending_scans = atomic_call.args[1]
+    assert thread_models is not None
+    assert isinstance(thread_models[0], ThreadModel)
+    assert pending_scans
+
     # 应该生成 FullScanPostsTask
-    queued_tasks = _drain_queue(queue)
+    queued_tasks = _drain_router(router)
     assert any(isinstance(item.content, FullScanPostsTask) for item in queued_tasks)
 
 
 @pytest.mark.asyncio
 async def test_threads_handler_new_thread_zero_replies():
     """测试 ThreadsTaskHandler 处理没有回复的新主题帖"""
-    Worker._memory_locks.clear()
-
     thread = make_thread(tid=1, reply_num=0)
     threads_response = make_threads_response([thread])
 
@@ -109,37 +119,37 @@ async def test_threads_handler_new_thread_zero_replies():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value={thread.tid}),
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(ScanThreadsTask(fid=thread.fid, fname=thread.fname, pn=1))
 
-    # 没有回复的主题帖应该直接保存元数据
-    thread_save_calls = [
-        call.args[0]
-        for call in datastore.save_items.await_args_list
-        if call.args and isinstance(call.args[0], list) and call.args[0] and isinstance(call.args[0][0], ThreadModel)
-    ]
-    assert thread_save_calls, "Expected thread models to be persisted for zero-reply thread"
+    # 没有回复的主题帖也应通过原子方法保存元数据
+    datastore.save_threads_and_pending_scans.assert_awaited_once()
+    atomic_call = datastore.save_threads_and_pending_scans.await_args
+    thread_models = atomic_call.args[0]
+    pending_scans = atomic_call.args[1]
+    assert thread_models is not None
+    assert isinstance(thread_models[0], ThreadModel)
+    assert pending_scans == []
 
     # 不应该生成 FullScanPostsTask
-    queued_tasks = _drain_queue(queue)
+    queued_tasks = _drain_router(router)
     assert not any(isinstance(item.content, FullScanPostsTask) for item in queued_tasks)
 
 
 @pytest.mark.asyncio
 async def test_threads_handler_old_thread_with_updates():
     """测试 ThreadsTaskHandler 处理有更新的旧主题帖"""
-    Worker._memory_locks.clear()
-
     # 旧主题帖：数据库中的 last_time 是 1，新抓取的是 100
     old_last_time = datetime.fromtimestamp(1)
     new_last_time = datetime.fromtimestamp(100)
@@ -154,21 +164,22 @@ async def test_threads_handler_old_thread_with_updates():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value=set()),  # 不是新帖
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[stored_thread]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(ScanThreadsTask(fid=thread.fid, fname=thread.fname, pn=1))
 
     # 应该生成 IncrementalScanPostsTask
-    queued_tasks = _drain_queue(queue)
+    queued_tasks = _drain_router(router)
     incremental_tasks = [t for t in queued_tasks if isinstance(t.content, IncrementalScanPostsTask)]
     assert len(incremental_tasks) == 1
     assert isinstance(incremental_tasks[0].content, IncrementalScanPostsTask)
@@ -178,8 +189,6 @@ async def test_threads_handler_old_thread_with_updates():
 @pytest.mark.asyncio
 async def test_threads_handler_backfill_enqueues_next_page():
     """测试 ThreadsTaskHandler 在回溯模式下生成下一页任务"""
-    Worker._memory_locks.clear()
-
     thread = make_thread(tid=1, reply_num=5)
     threads_response = make_threads_response([thread], has_more=True, current_page=1, total_page=3)
 
@@ -187,15 +196,16 @@ async def test_threads_handler_backfill_enqueues_next_page():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value={thread.tid}),
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(ScanThreadsTask(fid=thread.fid, fname=thread.fname, pn=1, backfill=True, max_pages=5))
@@ -204,7 +214,7 @@ async def test_threads_handler_backfill_enqueues_next_page():
     datastore.push_object_event.assert_not_called()
 
     # 应该生成下一页的 ScanThreadsTask
-    queued_tasks = _drain_queue(queue)
+    queued_tasks = _drain_router(router)
     next_page_tasks = [t for t in queued_tasks if isinstance(t.content, ScanThreadsTask) and t.content.pn == 2]
     assert len(next_page_tasks) == 1
     assert isinstance(next_page_tasks[0].content, ScanThreadsTask)
@@ -214,8 +224,6 @@ async def test_threads_handler_backfill_enqueues_next_page():
 @pytest.mark.asyncio
 async def test_threads_handler_filters_livepost():
     """测试 ThreadsTaskHandler 过滤直播帖"""
-    Worker._memory_locks.clear()
-
     normal_thread = make_thread(tid=1, reply_num=5, is_livepost=False)
     live_thread = make_thread(tid=2, reply_num=5, is_livepost=True)
     threads_response = make_threads_response([normal_thread, live_thread])
@@ -224,15 +232,16 @@ async def test_threads_handler_filters_livepost():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value={1}),  # 只有 tid=1 是新的
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(ScanThreadsTask(fid=10, fname="bar", pn=1))
@@ -248,8 +257,6 @@ async def test_threads_handler_filters_livepost():
 @pytest.mark.asyncio
 async def test_full_scan_posts_handler_process_page():
     """测试 FullScanPostsTaskHandler 处理回复页面"""
-    Worker._memory_locks.clear()
-
     post = make_post(pid=100, tid=1, floor=2, reply_num=0)
     posts_response = make_posts_response([post])
 
@@ -258,13 +265,15 @@ async def test_full_scan_posts_handler_process_page():
         filter_new_ids=AsyncMock(return_value={post.pid}),
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_scan=AsyncMock(),
+        add_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = FullScanPostsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(FullScanPostsTask(tid=post.tid))
@@ -285,8 +294,6 @@ async def test_full_scan_posts_handler_process_page():
 @pytest.mark.asyncio
 async def test_full_scan_posts_handler_generates_comment_task():
     """测试 FullScanPostsTaskHandler 在楼中楼超过10条时生成扫描任务"""
-    Worker._memory_locks.clear()
-
     # 回复有超过10条楼中楼
     post = make_post(pid=100, tid=1, floor=2, reply_num=15)
     posts_response = make_posts_response([post])
@@ -296,19 +303,21 @@ async def test_full_scan_posts_handler_generates_comment_task():
         filter_new_ids=AsyncMock(return_value={post.pid}),
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_scan=AsyncMock(),
+        add_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = FullScanPostsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(FullScanPostsTask(tid=post.tid))
 
     # 应该生成 FullScanCommentsTask
-    queued_tasks = _drain_queue(queue)
+    queued_tasks = _drain_router(router)
     comment_tasks = [t for t in queued_tasks if isinstance(t.content, FullScanCommentsTask)]
     assert len(comment_tasks) == 1
     assert isinstance(comment_tasks[0].content, FullScanCommentsTask)
@@ -316,11 +325,8 @@ async def test_full_scan_posts_handler_generates_comment_task():
 
 
 @pytest.mark.asyncio
-async def test_full_scan_posts_handler_updates_thread_metadata():
-    """测试 FullScanPostsTaskHandler 在完成后更新主题帖元数据"""
-    Worker._memory_locks.clear()
-
-    thread = make_thread(tid=1, reply_num=5)
+async def test_full_scan_posts_handler_removes_pending_marker():
+    """测试 FullScanPostsTaskHandler 在完成后移除 pending_scan 标记"""
     post = make_post(pid=100, tid=1, floor=2)
     posts_response = make_posts_response([post])
 
@@ -329,24 +335,21 @@ async def test_full_scan_posts_handler_updates_thread_metadata():
         filter_new_ids=AsyncMock(return_value=set()),
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_thread_scan=AsyncMock(),
+        add_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = FullScanPostsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
-    await handler.handle(FullScanPostsTask(tid=1, thread_dto=thread))
+    await handler.handle(FullScanPostsTask(tid=1))
 
-    # 应该保存主题帖元数据
-    thread_save_calls = [
-        call
-        for call in datastore.save_items.await_args_list
-        if call.args and isinstance(call.args[0], list) and call.args[0] and isinstance(call.args[0][0], ThreadModel)
-    ]
-    assert thread_save_calls, "Expected thread metadata to be updated"
+    # _finalize_thread 应该移除 pending_scan 标记
+    datastore.remove_pending_thread_scan.assert_awaited_with(1)
 
 
 # ==================== IncrementalScanPostsTaskHandler 测试 ====================
@@ -355,8 +358,6 @@ async def test_full_scan_posts_handler_updates_thread_metadata():
 @pytest.mark.asyncio
 async def test_incremental_scan_posts_handler():
     """测试 IncrementalScanPostsTaskHandler 增量扫描"""
-    Worker._memory_locks.clear()
-
     stored_last_time = datetime.fromtimestamp(1)
     new_post_time = datetime.fromtimestamp(100)
 
@@ -374,18 +375,19 @@ async def test_incremental_scan_posts_handler():
         get_posts_by_pids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
         update_thread_metadata=AsyncMock(),
+        add_pending_comment_scan=AsyncMock(),
     )
 
     class MockConfig:
         deep_scan_enabled = False
         deep_scan_depth = 3
 
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = IncrementalScanPostsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client, config=MockConfig()),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     target_last_time = datetime.fromtimestamp(200)
@@ -417,13 +419,14 @@ async def test_full_scan_comments_handler():
         filter_new_ids=AsyncMock(return_value={comment.cid}),
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = FullScanCommentsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(FullScanCommentsTask(tid=1, pid=100))
@@ -443,13 +446,14 @@ async def test_full_scan_comments_handler_backfill_no_push():
         filter_new_ids=AsyncMock(return_value={comment.cid}),
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = FullScanCommentsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(FullScanCommentsTask(tid=1, pid=100, backfill=True))
@@ -473,13 +477,14 @@ async def test_incremental_scan_comments_handler():
         filter_new_ids=AsyncMock(return_value={new_comment.cid}),  # 只有 cid=2000 是新的
         save_items=AsyncMock(),
         push_object_event=AsyncMock(),
+        remove_pending_comment_scan=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
     handler = IncrementalScanCommentsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     await handler.handle(IncrementalScanCommentsTask(tid=1, pid=100))
@@ -494,8 +499,6 @@ async def test_incremental_scan_comments_handler():
 @pytest.mark.asyncio
 async def test_worker_processes_task():
     """测试 Worker 处理任务"""
-    Worker._memory_locks.clear()
-
     thread = make_thread(tid=1, reply_num=0)
     threads_response = make_threads_response([thread])
 
@@ -503,16 +506,20 @@ async def test_worker_processes_task():
     datastore = SimpleNamespace(
         filter_new_ids=AsyncMock(return_value={thread.tid}),
         save_items=AsyncMock(),
+        save_threads_and_pending_scans=AsyncMock(),
         get_threads_by_tids=AsyncMock(return_value=[]),
         push_object_event=AsyncMock(),
     )
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
+    queue = router.threads_queue
 
     worker = Worker(
         worker_id=0,
         queue=queue,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
+        router=router,
+        lane="threads",
     )
 
     # 添加任务到队列
@@ -529,8 +536,7 @@ async def test_worker_processes_task():
         worker_task.cancel()
         try:
             await worker_task
-        except (asyncio.CancelledError, ValueError):
-            # ValueError 可能由于 task_done() 调用时机问题
+        except asyncio.CancelledError:
             pass
 
     await run_worker_briefly()
@@ -541,19 +547,17 @@ async def test_worker_processes_task():
 
 @pytest.mark.asyncio
 async def test_worker_memory_lock():
-    """测试 Worker 内存锁功能"""
-    Worker._memory_locks.clear()
-
+    """测试 LockManager 锁功能"""
     tb_client = SimpleNamespace()
     datastore = SimpleNamespace()
-    queue = UniquePriorityQueue()
+    router = QueueRouter()
 
     # 创建一个 handler 来测试锁
     handler = ThreadsTaskHandler(
         worker_id=0,
         container=create_mock_container(tb_client=tb_client),
         datastore=cast("Any", datastore),
-        queue=queue,
+        router=router,
     )
 
     # 第一次获取锁应该成功

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -466,6 +466,7 @@ async def test_full_scan_comments_handler():
 
     # 应该推送楼中楼事件
     datastore.push_object_event.assert_awaited_with("comment", comment)
+    datastore.remove_pending_comment_scan.assert_awaited_once_with(1, 100)
 
 
 @pytest.mark.asyncio
@@ -493,6 +494,7 @@ async def test_full_scan_comments_handler_backfill_no_push():
 
     # 回溯模式不应该推送事件
     datastore.push_object_event.assert_not_called()
+    datastore.remove_pending_comment_scan.assert_awaited_once_with(1, 100)
 
 
 # ==================== IncrementalScanCommentsTaskHandler 测试 ====================
@@ -524,6 +526,8 @@ async def test_incremental_scan_comments_handler():
 
     # 应该只推送新楼中楼
     datastore.push_object_event.assert_awaited_with("comment", new_comment)
+    # 增量扫描只应清理 incremental 标记，避免误删 full 标记
+    datastore.remove_pending_comment_scan.assert_awaited_once_with(1, 100, task_kind="incremental")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- 多通道架构:
  - 引入 `QueueRouter` 替代单一优先队列，将任务分流至三个独立通道。
  - `Worker` 绑定特定通道运行，支持独立的并发数配置。
- 任务中断恢复:
  - 新增用于持久化未完成的扫描任务的模型。
  - 更新 `DataStore` 支持 pending 状态的原子写入与删除。
  - 在 `Worker` 启动时扫描 pending 任务，并将其重新加入对应通道的队列。
- 分布式锁重构:
  - 将锁逻辑提取至 `lock.py`。
  - 实现 `LockManager` 协议，提供内存锁和 Redis 分布式锁两种实现。
- 测试与指标:
  - 更新 Prometheus 指标，`QUEUE_SIZE` 现在按 lane 标签统计。
  - 新增 `QueueRouter` 和 `LockManager` 的单元测试，并更新了相关集成测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Refactors the core scheduling/worker pipeline to route tasks across multiple queues and adds new DB-backed pending-scan state; regressions could cause missed/duplicated work or stuck queues during shutdown/restart.
> 
> **Overview**
> Introduces a **multi-lane task execution model** via `QueueRouter`, splitting the single priority queue into `threads`/`posts`/`comments` lanes with per-lane worker pools configurable through new `worker.{threads,posts,comments}` settings; graceful shutdown/join logic is updated to drain all lanes.
> 
> Adds **restart recovery for in-flight scans** by persisting pending thread/comment scans in new ORM tables (`PendingThreadScan`, `PendingCommentScan`) and extending `DataStore` with atomic upserts, conflict semantics ("full" dominates), and cleanup APIs; `main.py` now re-enqueues pending tasks on startup and workers mark scans complete by removing pending markers.
> 
> Refactors locking into a pluggable `LockManager` (`MemoryLockManager`/`RedisLockManager`) wired through `Container`, updates queue dedup semantics to release keys on `task_done`, and adjusts Prometheus/Grafana metrics (queue size labeled by `lane`, scraped items counter drops `status`, dashboard switches to API error metrics).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9df0aa3ef3085fc1a685ad85f99c810b19aea34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->